### PR TITLE
add missing ctx in constructor

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -78,6 +78,7 @@ class OAuth2 {
 
   async execute(handle, ctx, options) {
     let result = null;
+    this.ctx = ctx;
     const request = new Request(ctx.request);
     const response = new Response(replaceResponse(ctx.response));
     try {


### PR DESCRIPTION
Fix the missing `ctx` object in constructor method.
