### PR TITLE
Allow to customize error handler

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -9,6 +9,7 @@ module.exports = config => {
   exports.oAuth2Server = {
     debug: config.env === 'local',
     grants: [ 'password' ],
+    handleError: true,
   };
   return exports;
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -90,9 +90,9 @@ class OAuth2 {
       result = await this.server[handle](request, response, options);
       handleResponse(ctx, response);
     } catch (e) {
-      if(this.config.handleError){
+      if (this.config.handleError) {
         handleError(ctx, e, response);
-      }else{
+      } else {
         throw e;
       }
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -90,7 +90,11 @@ class OAuth2 {
       result = await this.server[handle](request, response, options);
       handleResponse(ctx, response);
     } catch (e) {
-      handleError(ctx, e, response);
+      if(this.config.handleError){
+        handleError(ctx, e, response);
+      }else{
+        throw e;
+      }
     }
     return result;
   }

--- a/test/oauth2-server.test.js
+++ b/test/oauth2-server.test.js
@@ -97,14 +97,14 @@ describe('test/oauth2-server.test.js', () => {
     before(() => {
       mm(app.config.oAuth2Server, 'handleError', false);
     });
-    
+
     it('should thows execption', () => {
-       return request(app.callback())
+      return request(app.callback())
         .get('/user/authenticate')
         .set({
           Authorization: 'Bearer 838734b4115734de1f87f02a9da9106ddec7cc31',
         })
         .expect(500);
-    })
+    });
   });
 });

--- a/test/oauth2-server.test.js
+++ b/test/oauth2-server.test.js
@@ -93,4 +93,18 @@ describe('test/oauth2-server.test.js', () => {
       })
       .expect(200);
   });
+  describe('Don\'t handleError', () => {
+    before(() => {
+      mock(app.config.oAuth2Server, 'handleError', false);
+    });
+    
+    it('should thows execption, () => {
+       return request(app.callback())
+        .get('/user/authenticate')
+        .set({
+          Authorization: 'Bearer 838734b4115734de1f87f02a9da9106ddec7cc31',
+        })
+        .expect(500);
+    })
+  });
 });

--- a/test/oauth2-server.test.js
+++ b/test/oauth2-server.test.js
@@ -95,7 +95,7 @@ describe('test/oauth2-server.test.js', () => {
   });
   describe('Don\'t handleError', () => {
     before(() => {
-      mock(app.config.oAuth2Server, 'handleError', false);
+      mm(app.config.oAuth2Server, 'handleError', false);
     });
     
     it('should thows execption', () => {

--- a/test/oauth2-server.test.js
+++ b/test/oauth2-server.test.js
@@ -98,7 +98,7 @@ describe('test/oauth2-server.test.js', () => {
       mock(app.config.oAuth2Server, 'handleError', false);
     });
     
-    it('should thows execption, () => {
+    it('should thows execption', () => {
        return request(app.callback())
         .get('/user/authenticate')
         .set({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change
As you always catch errors it is impossible to customizing errors for instance it is not possible to have a JSON response where we have UnauthorizedRequestError , or we cannot prevent `ctx.app.emit('error', e, ctx);` emitting , it is not good to log UnauthorizedRequestError or UnauthorizedClientError in production mode
